### PR TITLE
Rename module and fix lazy init crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-provider-rode
 
-[![test badge](https://github.com/alexashley/terraform-provider-rode/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/alexashley/terraform-provider-rode/actions/workflows/test.yaml?query=branch%3Amain)
+[![test badge](https://github.com/rode/terraform-provider-rode/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/rode/terraform-provider-rode/actions/workflows/test.yaml?query=branch%3Amain)
 
 
 A Terraform provider for [rode](https://github.com/rode/rode).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alexashley/terraform-provider-rode
+module github.com/rode/terraform-provider-rode
 
 go 1.16
 

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -15,11 +15,12 @@
 package provider
 
 import (
+	"log"
+	"sync"
+
 	"github.com/rode/rode/common"
 	"github.com/rode/rode/proto/v1alpha1"
 	"google.golang.org/grpc"
-	"log"
-	"sync"
 )
 
 type rodeClient struct {

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -30,8 +30,8 @@ type rodeClient struct {
 	userAgent string
 }
 
+var clientInitErr error
 func (r *rodeClient) init() error {
-	var initErr error
 	r.Once.Do(func() {
 		log.Println("[DEBUG] Rode client init")
 		rode, err := common.NewRodeClient(
@@ -44,9 +44,9 @@ func (r *rodeClient) init() error {
 		}
 
 		r.RodeClient = rode
-		initErr = err
+		clientInitErr = err
 		log.Println("[DEBUG] Rode client init successful")
 	})
 
-	return initErr
+	return clientInitErr
 }

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -31,6 +31,7 @@ type rodeClient struct {
 }
 
 var clientInitErr error
+
 func (r *rodeClient) init() error {
 	r.Once.Do(func() {
 		log.Println("[DEBUG] Rode client init")

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,10 +16,11 @@ package provider
 
 import (
 	"context"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rode/rode/common"
-	"log"
 )
 
 func init() {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -16,10 +16,11 @@ package provider
 
 import (
 	_ "embed"
-	"github.com/brianvoe/gofakeit/v6"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"os"
 	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var (

--- a/internal/provider/resource_rode_policy.go
+++ b/internal/provider/resource_rode_policy.go
@@ -17,11 +17,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rode/rode/proto/v1alpha1"
-	"log"
 )
 
 func resourcePolicy() *schema.Resource {

--- a/internal/provider/resource_rode_policy_assignment.go
+++ b/internal/provider/resource_rode_policy_assignment.go
@@ -17,6 +17,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -24,8 +27,6 @@ import (
 	"github.com/rode/rode/proto/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"log"
-	"strings"
 )
 
 var (

--- a/internal/provider/resource_rode_policy_assignment_test.go
+++ b/internal/provider/resource_rode_policy_assignment_test.go
@@ -18,15 +18,16 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/rode/rode/proto/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"regexp"
-	"strings"
-	"testing"
 )
 
 func TestAccPolicyAssignment_basic(t *testing.T) {

--- a/internal/provider/resource_rode_policy_group.go
+++ b/internal/provider/resource_rode_policy_group.go
@@ -17,12 +17,13 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rode/rode/proto/v1alpha1"
-	"log"
-	"regexp"
 )
 
 var (

--- a/internal/provider/resource_rode_policy_group_test.go
+++ b/internal/provider/resource_rode_policy_group_test.go
@@ -17,12 +17,13 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/rode/rode/proto/v1alpha1"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/rode/rode/proto/v1alpha1"
 )
 
 func TestAccPolicyGroup_basic(t *testing.T) {

--- a/internal/provider/resource_rode_policy_test.go
+++ b/internal/provider/resource_rode_policy_test.go
@@ -17,12 +17,13 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/rode/rode/proto/v1alpha1"
 	"google.golang.org/protobuf/proto"
-	"strings"
-	"testing"
 )
 
 func TestAccPolicy_basic(t *testing.T) {

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -16,11 +16,12 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-uuid"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func formatProtoTimestamp(timestamp *timestamppb.Timestamp) string {

--- a/main.go
+++ b/main.go
@@ -17,9 +17,10 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/alexashley/terraform-provider-rode/internal/provider"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"github.com/rode/terraform-provider-rode/internal/provider"
 )
 
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs


### PR DESCRIPTION
Closes #27 
Closes #26 

Now if there's an error initializing the Rode client, the client init will return the same error to all callers, which Terraform can display:

```shell
╷
│ Error: error connecting to rode server: context deadline exceeded
│
│   with module.rode.rode_policy_group.rode_demo,
│   on ../modules/rode/policy.tf line 29, in resource "rode_policy_group" "rode_demo":
│   29: resource "rode_policy_group" "rode_demo" {
```